### PR TITLE
KAN-35 Update type color of card

### DIFF
--- a/src/modules/cardTypes/cardTypes.module.ts
+++ b/src/modules/cardTypes/cardTypes.module.ts
@@ -3,6 +3,7 @@ import { CardTypesService } from './cardTypes.service';
 import { CardTypesController } from './cardTypes.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CardTypesEntity } from './entities/cardTypes.entity';
+import { CardEntity } from '../card/entities/card.entity';
 import { CompanyModule } from '../company/company.module';
 import { UsersModule } from '../users/users.module';
 import { SiteModule } from '../site/site.module';
@@ -12,10 +13,11 @@ import { FirebaseModule } from '../firebase/firebase.module';
 @Module({
   imports: [
     SiteModule,
+    CardEntity,
     CompanyModule,
     UsersModule,
     FirebaseModule,
-    TypeOrmModule.forFeature([CardTypesEntity, CardTypesCatalogEntity]),
+    TypeOrmModule.forFeature([CardTypesEntity, CardTypesCatalogEntity,CardEntity]),
   ],
   controllers: [CardTypesController],
   providers: [CardTypesService],

--- a/src/modules/cardTypes/cardTypes.service.ts
+++ b/src/modules/cardTypes/cardTypes.service.ts
@@ -99,11 +99,11 @@ export class CardTypesService {
 
   update = async (updateCardTypesDTO: UpdateCardTypesDTO) => {
     try {
-      const foundCardTypes = await this.cardTypesRepository.findOneBy({
+      const currentCardType = await this.cardTypesRepository.findOneBy({
         id: updateCardTypesDTO.id,
       });
   
-      if (!foundCardTypes) {
+      if (!currentCardType) {
         throw new NotFoundCustomException(
           NotFoundCustomExceptionType.CARDTYPES,
         );
@@ -116,54 +116,53 @@ export class CardTypesService {
         if (!foundUser) {
           throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
         }
-        foundCardTypes.responsableId = updateCardTypesDTO.responsableId;
-        foundCardTypes.responsableName = foundUser.name;
-        foundCardTypes.email = foundUser.email;
+        currentCardType.responsableId = updateCardTypesDTO.responsableId;
+        currentCardType.responsableName = foundUser.name;
+        currentCardType.email = foundUser.email;
       }
-
-      foundCardTypes.methodology = updateCardTypesDTO.methodology;
-      foundCardTypes.name = updateCardTypesDTO.name;
-      foundCardTypes.description = updateCardTypesDTO.description;
-      foundCardTypes.quantityPicturesCreate = updateCardTypesDTO.quantityPicturesCreate;
-      foundCardTypes.quantityAudiosCreate = updateCardTypesDTO.quantityAudiosCreate;
-      foundCardTypes.quantityVideosCreate = updateCardTypesDTO.quantityVideosCreate;
-      foundCardTypes.audiosDurationCreate = updateCardTypesDTO.audiosDurationCreate;
-      foundCardTypes.videosDurationCreate = updateCardTypesDTO.videosDurationCreate;
-      foundCardTypes.quantityPicturesClose = updateCardTypesDTO.quantityPicturesClose;
-      foundCardTypes.quantityAudiosClose = updateCardTypesDTO.quantityAudiosClose;
-      foundCardTypes.quantityVideosClose = updateCardTypesDTO.quantityVideosClose;
-      foundCardTypes.audiosDurationClose = updateCardTypesDTO.audiosDurationClose;
-      foundCardTypes.videosDurationClose = updateCardTypesDTO.videosDurationClose;
-      foundCardTypes.quantityPicturesPs = updateCardTypesDTO.quantityPicturesPs;
-      foundCardTypes.quantityAudiosPs = updateCardTypesDTO.quantityAudiosPs;
-      foundCardTypes.audiosDurationPs = updateCardTypesDTO.audiosDurationPs;
-      foundCardTypes.quantityVideosPs = updateCardTypesDTO.quantityVideosPs;
-      foundCardTypes.videosDurationPs = updateCardTypesDTO.videosDurationPs;
-      foundCardTypes.status = updateCardTypesDTO.status;
+  
+      currentCardType.methodology = updateCardTypesDTO.methodology;
+      currentCardType.name = updateCardTypesDTO.name;
+      currentCardType.description = updateCardTypesDTO.description;
+      currentCardType.quantityPicturesCreate = updateCardTypesDTO.quantityPicturesCreate;
+      currentCardType.quantityAudiosCreate = updateCardTypesDTO.quantityAudiosCreate;
+      currentCardType.quantityVideosCreate = updateCardTypesDTO.quantityVideosCreate;
+      currentCardType.audiosDurationCreate = updateCardTypesDTO.audiosDurationCreate;
+      currentCardType.videosDurationCreate = updateCardTypesDTO.videosDurationCreate;
+      currentCardType.quantityPicturesClose = updateCardTypesDTO.quantityPicturesClose;
+      currentCardType.quantityAudiosClose = updateCardTypesDTO.quantityAudiosClose;
+      currentCardType.quantityVideosClose = updateCardTypesDTO.quantityVideosClose;
+      currentCardType.audiosDurationClose = updateCardTypesDTO.audiosDurationClose;
+      currentCardType.videosDurationClose = updateCardTypesDTO.videosDurationClose;
+      currentCardType.quantityPicturesPs = updateCardTypesDTO.quantityPicturesPs;
+      currentCardType.quantityAudiosPs = updateCardTypesDTO.quantityAudiosPs;
+      currentCardType.audiosDurationPs = updateCardTypesDTO.audiosDurationPs;
+      currentCardType.quantityVideosPs = updateCardTypesDTO.quantityVideosPs;
+      currentCardType.videosDurationPs = updateCardTypesDTO.videosDurationPs;
+      currentCardType.status = updateCardTypesDTO.status;
   
       if (updateCardTypesDTO.status !== stringConstants.A) {
-        foundCardTypes.deletedAt = new Date();
+        currentCardType.deletedAt = new Date();
       }
-      foundCardTypes.updatedAt = new Date();
+      currentCardType.updatedAt = new Date();
   
       let affectedRows = 0;
-
-      if (updateCardTypesDTO.color !== foundCardTypes.color) {
-        foundCardTypes.color = updateCardTypesDTO.color;
   
-
+      if (updateCardTypesDTO.color !== currentCardType.color) {
+        currentCardType.color = updateCardTypesDTO.color;
+  
         const result = await this.cardsRepository
           .createQueryBuilder()
           .update()
           .set({ cardTypeColor: updateCardTypesDTO.color }) 
-          .where('cardTypeId = :cardTypeId', { cardTypeId: foundCardTypes.id }) 
+          .where('cardTypeId = :cardTypeId', { cardTypeId: currentCardType.id }) 
           .execute();
   
         affectedRows = result.affected;
       }
   
       const tokens = await this.usersService.getSiteUsersTokens(
-        foundCardTypes.siteId,
+        currentCardType.siteId,
       );
       await this.firebaseService.sendMultipleMessage(
         new NotificationDTO(
@@ -175,16 +174,16 @@ export class CardTypesService {
       );
   
       const response = {
-        message: `Card type updated successfully.`,
+        message: stringConstants.cardTypeUpdate,
         updatedCardsCount: affectedRows, 
-        updatedCardType: await this.cardTypesRepository.save(foundCardTypes), 
+        updatedCardType: await this.cardTypesRepository.save(currentCardType), 
       };
   
       return response;
     } catch (exception) {
       HandleException.exception(exception);
     }
-  };  
+  };   
 
   findById = async (id: number) => {
     try {

--- a/src/modules/cardTypes/cardTypes.service.ts
+++ b/src/modules/cardTypes/cardTypes.service.ts
@@ -120,8 +120,7 @@ export class CardTypesService {
         foundCardTypes.responsableName = foundUser.name;
         foundCardTypes.email = foundUser.email;
       }
-  
-      // Actualizar los datos del CardType
+
       foundCardTypes.methodology = updateCardTypesDTO.methodology;
       foundCardTypes.name = updateCardTypesDTO.name;
       foundCardTypes.description = updateCardTypesDTO.description;
@@ -148,20 +147,18 @@ export class CardTypesService {
       foundCardTypes.updatedAt = new Date();
   
       let affectedRows = 0;
-  
-      // Actualizar el color de las tarjetas relacionadas si cambia el color del CardType
+
       if (updateCardTypesDTO.color !== foundCardTypes.color) {
         foundCardTypes.color = updateCardTypesDTO.color;
   
-        // Usar QueryBuilder para actualizar tarjetas relacionadas
+
         const result = await this.cardsRepository
           .createQueryBuilder()
           .update()
-          .set({ cardTypeColor: updateCardTypesDTO.color }) // Campo a actualizar
-          .where('cardTypeId = :cardTypeId', { cardTypeId: foundCardTypes.id }) // Filtro por cardTypeId
+          .set({ cardTypeColor: updateCardTypesDTO.color }) 
+          .where('cardTypeId = :cardTypeId', { cardTypeId: foundCardTypes.id }) 
           .execute();
   
-        // Guardar el número de filas afectadas
         affectedRows = result.affected;
       }
   
@@ -177,11 +174,10 @@ export class CardTypesService {
         tokens,
       );
   
-      // Retornar mensaje al cliente con la cantidad de tarjetas actualizadas
       const response = {
         message: `Card type updated successfully.`,
-        updatedCardsCount: affectedRows, // Cantidad de tarjetas actualizadas
-        updatedCardType: await this.cardTypesRepository.save(foundCardTypes), // CardType actualizado
+        updatedCardsCount: affectedRows, 
+        updatedCardType: await this.cardTypesRepository.save(foundCardTypes), 
       };
   
       return response;

--- a/src/utils/string.constant.ts
+++ b/src/utils/string.constant.ts
@@ -32,7 +32,7 @@ export const stringConstants = {
   mechanicAssignmentMessage: 'te ha asignado la tarjeta:',
   cardsNotificationType: 'SYNC_REMOTE_CARDS',
   updateAppNotificationType: 'UPDATE_APP',
-
+  cardTypeUpdate: 'Tipo de tarjeta actualizado con éxito.',
   //Types of evidences
   AUCR: 'AUCR',
   AUCL: 'AUCL',


### PR DESCRIPTION
### Feature / Bug Description
This pull request implements a feature where the cardTypeColor field in all cards is updated when the associated cardType color changes. This ensures data consistency between cardType and its related cards

### Solution
Added logic in the updateCardTypes method to:
Use a QueryBuilder for updating all related cards in the database when the color field of a cardType is modified.
Update only the cardTypeColor of the cards if the color value changes.
Enhanced the API response to include:
A success message.
The number of updated cards (updatedCardsCount).
The updated cardType object for confirmation.

### Notes
The response body has been enhanced to provide meaningful data to the client for verification and debugging.
Includes screenshots to demonstrate the changes in action.

### Tickets
[TICKET] (https://one-sm.atlassian.net/browse/KAN-35)

### Screenshots / Screencasts
CardType relationship with Cards:

Request & Response demonstrating the change:
![image](https://github.com/user-attachments/assets/73266dc7-c669-4d70-b1c0-2aad6767f8a3)

![image](https://github.com/user-attachments/assets/5d1bf22c-fe76-4636-b327-a2db8460e21f)

