### PR TITLE
KAN-32 Send push notification

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -887,7 +887,7 @@ export class CardService {
       await this.firebaseService.sendNewMessage(
         new NotificationDTO(
           stringConstants.cardAssignedTitle.replace('[card_id]', card.id.toString()),
-          stringConstants.cardAssignedBody,
+          stringConstants.cardAssignedDescription,
           stringConstants.emptyNotificationType,
         ),
         token,

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -886,9 +886,9 @@ export class CardService {
       
       await this.firebaseService.sendNewMessage(
         new NotificationDTO(
-          stringConstants.cardAssignmentTitle,
-          `<${user.name}> ${stringConstants.mechanicAssignmentMessage} <#${card.siteCardId} ${card.cardTypeName}>`,
-          stringConstants.cardsNotificationType,
+          stringConstants.cardAssignedTitle.replace('[card_id]', card.id.toString()),
+          stringConstants.cardAssignedBody,
+          stringConstants.emptyNotificationType,
         ),
         token,
       );

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -23,6 +23,7 @@ import { SendCodeDTO } from './models/send.code.dto';
 import { ResetPasswordDTO } from './models/reset.password.dto';
 import { SetAppTokenDTO } from './models/set.app.token.dto';
 import { FirebaseService } from '../firebase/firebase.service';
+import { NotificationDTO } from '../firebase/models/firebase.request.dto';
 import { UserHasSitesEntity } from './entities/user.has.sites.entity';
 import { CreateUsersDTO } from '../file-upload/dto/create.users.dto';
 import { UsersAndSitesDTO } from '../file-upload/dto/users.and.sites.dto';
@@ -133,6 +134,7 @@ export class UsersService {
       relations: { userHasSites: { site: true } },
     });
   };
+  
   update = async (user: UserEntity) => {
     const exists = await this.userRepository.existsBy({ email: user.email });
     if (!exists) {
@@ -323,6 +325,7 @@ export class UsersService {
       HandleException.exception(exception);
     }
   };
+  
   updateUser = async (updateUserDTO: UpdateUserDTO) => {
     try {
       const [user, emailIsNotUnique, site, roles] = await Promise.all([
@@ -363,10 +366,23 @@ export class UsersService {
       user.uploadCardDataWithDataNet = updateUserDTO.uploadCardDataWithDataNet;
       user.uploadCardEvidenceWithDataNet =
         updateUserDTO.uploadCardEvidenceWithDataNet;
+      user.status = updateUserDTO.status;  
       user.updatedAt = new Date();
 
       await this.userRepository.save(user);
 
+      if (updateUserDTO.status === 'I') {
+        const token = await this.getUserToken(user.id);
+        await this.firebaseService.sendNewMessage(
+          new NotificationDTO(
+            stringConstants.closeSessionTitle,
+            stringConstants.closeSessionDescription,
+            stringConstants.closeSessionType,
+          ),
+          token,
+        );
+      }
+      
       return await this.roleService.updateUserRoles(user, roles);
     } catch (exception) {
       console.log(exception);

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -371,7 +371,7 @@ export class UsersService {
 
       await this.userRepository.save(user);
 
-      if (updateUserDTO.status === 'I') {
+      if (updateUserDTO.status === stringConstants.inactiveStatus) {
         const token = await this.getUserToken(user.id);
         await this.firebaseService.sendNewMessage(
           new NotificationDTO(

--- a/src/utils/string.constant.ts
+++ b/src/utils/string.constant.ts
@@ -32,6 +32,9 @@ export const stringConstants = {
   mechanicAssignmentMessage: 'te ha asignado la tarjeta:',
   cardsNotificationType: 'SYNC_REMOTE_CARDS',
   updateAppNotificationType: 'UPDATE_APP',
+  cardAssignedTitle: 'Card [card_id] has been assigned to you.',
+  cardAssignedBody: 'You have a new card assigned',
+  emptyNotificationType: '',
 
   //Types of evidences
   AUCR: 'AUCR',

--- a/src/utils/string.constant.ts
+++ b/src/utils/string.constant.ts
@@ -33,8 +33,11 @@ export const stringConstants = {
   cardsNotificationType: 'SYNC_REMOTE_CARDS',
   updateAppNotificationType: 'UPDATE_APP',
   cardAssignedTitle: 'Card [card_id] has been assigned to you.',
-  cardAssignedBody: 'You have a new card assigned',
+  cardAssignedDescription: 'You have a new card assigned',
   emptyNotificationType: '',
+  closeSessionTitle: 'Session Closed',
+  closeSessionDescription: 'Your session has been closed.',
+  closeSessionType: 'CLOSE_SESSION',
 
   //Types of evidences
   AUCR: 'AUCR',


### PR DESCRIPTION
### Feature / Bug Description  
When a mechanic is assigned to a card, we need to send a push notification to notify the user. The notification must include:  

- **Title**:  
  `Card [card_id] has been assigned to you.`  

- **Body**:  
  `You have a new card assigned.`  

- **Type**:  
  An empty string (`""`).  

Additionally, when a user's status is updated to **Inactive**, a push notification must be sent with the `notification_type` value set to **"CLOSE_SESSION"**.  

The text content for all notifications has been centralized in the `Strings.ts` file to maintain consistency.  

---

### Solution  

#### Changes to `updateCardMechanic` Method  
- Updated the notification **title** to dynamically include the `card ID`.  

#### Changes to `updateUser` Method in `users.service`  
- Added logic to send a **push notification** when the user's status is updated to **Inactive**.  
- The notification includes:  
   - `notification_type` with the value **"CLOSE_SESSION"**.  

#### Centralized Notification Constants  
- Centralized all text constants (title, description, and type) in the `Strings.ts` file.  

#### Type Conversion Fix  
- Ensured `card.id` is converted to a string before replacing placeholders to avoid type errors.  

---

### Notes  
- Added new constants to **`Strings.ts`**.  
- Fixed the type error with `replace` by converting `card.id` to a string.  
- Verified the changes through testing to ensure:  
   - Notifications are sent as expected.  

### Tickets
[TICKET] (https://one-sm.atlassian.net/browse/KAN-32)
[TICKET] (https://one-sm.atlassian.net/browse/KAN-33)

### Screenshots / Screencasts
![n1](https://github.com/user-attachments/assets/dcf6f5a0-d6c5-4010-b3f0-095ea2e01b0a)
![image](https://github.com/user-attachments/assets/0c7c5271-a1d1-4d1a-80b5-441b2a103504)
![session](https://github.com/user-attachments/assets/01b5b41a-d843-4b15-9ded-654729d5d966)