### PR TITLE
KAN-23 Create card with request date

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -152,13 +152,13 @@ export class CardService {
       const cardUUIDisNotUnique = await this.cardRepository.exists({
         where: { cardUUID: createCardDTO.cardUUID },
       });
-
+  
       if (cardUUIDisNotUnique) {
         throw new ValidationException(
           ValidationExceptionType.DUPLICATE_CARD_UUID,
         );
       }
-
+  
       const site = await this.siteService.findById(createCardDTO.siteId);
       var priority = new PriorityEntity();
       if (createCardDTO.priorityId && createCardDTO.priorityId !== 0) {
@@ -174,7 +174,7 @@ export class CardService {
         createCardDTO.preclassifierId,
       );
       const creator = await this.userService.findById(createCardDTO.creatorId);
-
+  
       if (!site) {
         throw new NotFoundCustomException(NotFoundCustomExceptionType.SITE);
       } else if (!node) {
@@ -192,21 +192,21 @@ export class CardService {
       } else if (!creator) {
         throw new NotFoundCustomException(NotFoundCustomExceptionType.USER);
       }
-
+  
       var lastInsertedCard;
       lastInsertedCard = await this.cardRepository.findOne({
         order: { id: 'DESC' },
         where: { siteId: site.id },
       });
-
+  
       const levelMap = await this.levelService.findAllLevelsBySite(site.id);
       const { area, location } = this.levelService.getSuperiorLevelsById(
         String(node.id),
         levelMap,
       );
-
-      const currentDate = new Date();
-
+  
+      const createdAt = new Date(createCardDTO.cardCreationDate);
+  
       const card = await this.cardRepository.create({
         ...createCardDTO,
         siteCardId: lastInsertedCard ? lastInsertedCard.siteCardId + 1 : 1,
@@ -236,21 +236,21 @@ export class CardService {
         preclassifierCode: preclassifier.preclassifierCode,
         preclassifierDescription: preclassifier.preclassifierDescription,
         creatorName: creator.name,
-        createdAt: currentDate,
+        createdAt: createdAt,
         cardDueDate:
-          priority.id && addDaysToDate(currentDate, priority.priorityDays),
+          priority.id && addDaysToDate(createdAt, priority.priorityDays),
         commentsAtCardCreation: createCardDTO.comments,
         appVersion: createCardDTO.appVersion,
         appSo: createCardDTO.appSo,
       });
-
+      
       await this.cardRepository.save(card);
       lastInsertedCard = await this.cardRepository.find({
         order: { id: 'DESC' },
         take: 1,
       });
       const cardAssignEvidences = lastInsertedCard[0];
-
+  
       await Promise.all(
         createCardDTO.evidences.map(async (evidence) => {
           switch (evidence.type) {
@@ -287,12 +287,12 @@ export class CardService {
             evidenceType: evidence.type,
             cardId: cardAssignEvidences.id,
             siteId: site.id,
-            createdAt: new Date(),
+            createdAt: createdAt,
           });
           await this.evidenceRepository.save(evidenceToCreate);
         }),
       );
-
+  
       const tokens =
         await this.userService.getSiteUsersTokensExcludingOwnerUser(
           cardAssignEvidences.siteId,
@@ -306,13 +306,13 @@ export class CardService {
         ),
         tokens,
       );
-
+  
       return await this.cardRepository.save(cardAssignEvidences);
     } catch (exception) {
       console.log(exception);
       HandleException.exception(exception);
     }
-  };
+  };  
   updateDefinitivesolution = async (
     updateDefinitivesolutionDTO: UpdateDefinitiveSolutionDTO,
   ) => {


### PR DESCRIPTION
### Feature / Bug Description
The `createCard` method was using `new Date()` for the `createdAt` property instead of taking the date provided in the request (`createCardDTO.cardCreationDate`).

### Solution
Replaced all instances of `new Date()` with `createCardDTO.cardCreationDate` to ensure the creation date is consistent with the request data.

### Notes
- Validated the `createdAt` format by converting it to a `Date` object.
- Ensured no redundant `new Date()` calls remain in the method.

### Tickets
[TICKET] (https://one-sm.atlassian.net/browse/KAN-23)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/d4ddafe0-8374-4750-85e9-454cc9fd0555)

