### PR TITLE
KAN-49 Generate a new UUID if it already exists

### DIFF
--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -149,15 +149,20 @@ export class CardService {
 
   create = async (createCardDTO: CreateCardDTO) => {
     try {
-      const cardUUIDisNotUnique = await this.cardRepository.exists({
-        where: { cardUUID: createCardDTO.cardUUID },
+
+      let cardUUID = createCardDTO.cardUUID;
+      let cardUUIDisNotUnique = await this.cardRepository.exists({
+        where: { cardUUID: cardUUID },
       });
 
-      if (cardUUIDisNotUnique) {
-        throw new ValidationException(
-          ValidationExceptionType.DUPLICATE_CARD_UUID,
-        );
+      while (cardUUIDisNotUnique) {
+        cardUUID = require('crypto').randomUUID();
+        cardUUIDisNotUnique = await this.cardRepository.exists({
+          where: { cardUUID: cardUUID },
+        });
       }
+
+      createCardDTO.cardUUID = cardUUID;
 
       const site = await this.siteService.findById(createCardDTO.siteId);
       var priority = new PriorityEntity();


### PR DESCRIPTION
### Feature / Bug Description
**Bug**: When creating a card, if the provided UUID already exists in the database, the process fails with a duplicate UUID error.  
**Root Cause**: The `create` method did not handle duplicate UUIDs, leading to a validation exception when a duplicate was found.  
**How to Reproduce**: Attempt to create a card with a UUID that is already present in the database.

---

### Solution
- Added logic to the `create` method to check if the provided UUID already exists.  
- If a duplicate UUID is found, a new UUID is generated using Node.js's `crypto.randomUUID()` until a unique UUID is validated.  

---

### Notes
- Replaced the direct exception for duplicate UUIDs with a loop that ensures a unique UUID is generated.  
- Used the native `crypto` library instead of external dependencies like `uuid` to minimize overhead.  
- Verified the fix through testing with scenarios involving duplicate UUIDs.  

### Tickets
[TICKET] (https://one-sm.atlassian.net/browse/KAN-49)

### Screenshots / Screencasts
An existing card
![image](https://github.com/user-attachments/assets/acba67a0-12c8-4494-a3d0-cf0bf806c5b6)
Using the same uuid
![image](https://github.com/user-attachments/assets/e6972f73-bb3f-4e4e-ac28-7e8e239fce27)

