### PR TITLE
KAN-70 Fix push notification

### DIFF
--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -187,17 +187,23 @@ export class UsersService {
   ) => {
     try {
       const users = await this.userRepository.find({
-        where: { userHasSites: { site: { id: siteId } }, id: Not(userId) },
+        where: {
+          userHasSites: { site: { id: siteId } },
+          id: Not(userId),
+        },
         select: ['appToken'],
       });
 
-      const tokens = users.map((user) => user.appToken);
-
+      const tokens = users
+        .map((user) => user.appToken)
+        .filter((token) => token);
+  
       return tokens;
     } catch (exception) {
       HandleException.exception(exception);
     }
   };
+  
 
   getUserToken = async (userId: number) => {
     try {


### PR DESCRIPTION
### Feature / Bug Description
No notification was sent to site users when a card was added

### Solution
Modify the `getSiteUsersTokensExcludingOwnerUser` method

### Notes
n/a

### Tickets
[TICKET] (https://one-sm.atlassian.net/browse/KAN-70)

### Screenshots / Screencasts
I tried entering my user ID and I didn't receive a notification. When I entered another id, I did receive a notification
![image](https://github.com/user-attachments/assets/2925781e-9f4e-42dd-a537-d214a23d3c37)
![image](https://github.com/user-attachments/assets/15594aba-6ea1-4872-9cd5-7edaa43e9ea7)
![image](https://github.com/user-attachments/assets/63995cc0-bb14-4eda-b85d-aa8f1f970343)

