### PR TITLE
AN - 73 Add Drilldown on level details (backend) 

### DIFF
--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -207,4 +207,11 @@ export class CardController {
       cardTypeName,
     });
   }
+  @Get('by-level/:levelId')
+  async getCardsByLevel(
+    @Param('levelId') levelId: number,
+    @Query('siteId') siteId: number,
+  ) {
+    return await this.cardService.getCardsByLevelId(siteId, levelId);
+  }
 }


### PR DESCRIPTION
### Feature / Bug Description
Add the tag list on the level details showind the tags releated with the selected level


### Solution
Add a service to get all the cards releated with a level by id.
### Notes
Add some notes

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-73)

### Screenshots / Screencasts