### PR TITLE
KAN-81 A level controller that includes the location

### DIFF
--- a/src/modules/level/level.controller.ts
+++ b/src/modules/level/level.controller.ts
@@ -14,6 +14,11 @@ export class LevelController {
   findActiveLevelsByCompanyId(@Param('siteId') siteId: number) {
     return this.levelService.findSiteActiveLevels(+siteId);
   }
+  @Get('/all/:siteId/location')
+  @ApiParam({ name: 'siteId', required: true, example: 1 })
+  async findActiveLevelsByCompanyIdWithLocation(@Param('siteId') siteId: number) {
+    return await this.levelService.findActiveLevelsWithCardLocation(+siteId);
+  }
   @Get('/site/:siteId')
   @ApiParam({ name: 'siteId', required: true, example: 1 })
   findLevelsByCompanyId(@Param('siteId') siteId: number) {

--- a/src/modules/level/level.service.ts
+++ b/src/modules/level/level.service.ts
@@ -265,4 +265,35 @@ export class LevelService {
     const result = await this.levelRepository.query(query, [superiorId]);
     return result.map((row) => row.id);
   };
+  async findActiveLevelsWithCardLocation(siteId: number) {
+    try {
+      const levels = await this.findSiteActiveLevels(siteId);
+      const levelMap = new Map<number, any>();
+      levels.forEach(level => levelMap.set(level.id, level));
+      return levels.map(level => ({
+        ...level,
+        levelLocation: this.buildLevelLocation(level.id, levelMap),
+      }));
+    } catch (exception) {
+      HandleException.exception(exception);
+    }
+  }
+  
+  private buildLevelLocation(levelId: number, levelMap: Map<number, any>): string {
+    const path: string[] = [];
+    let currentLevel = levelMap.get(levelId);
+    if (!currentLevel) {
+      return '';
+    }
+    while (currentLevel) {
+      path.unshift(currentLevel.name); 
+      if (!currentLevel.superiorId || currentLevel.superiorId === "0") {
+        break; 
+      }
+      currentLevel = levelMap.get(currentLevel.superiorId);
+    }
+  
+    return path.join('/'); 
+  }
+  
 }


### PR DESCRIPTION
### Feature / Bug Description
Added an endpoint to retrieve active levels along with their hierarchical path (levelLocation). The path is dynamically constructed from the superiorId hierarchy, ensuring a structured representation of levels within a site.

### Solution
Added a new endpoint to retrieve active levels with their full hierarchical path (levelLocation).

Implemented a recursive function to construct the levelLocation from the superiorId hierarchy.
Optimized the lookup process using a Map for efficient access to levels.
Ensured correct path formatting in "Parent/Child/Subchild" format.

### Notes
The function prevents infinite loops by stopping at the root level.
Improved performance by avoiding redundant queries.

### Tickets
[TICKET] (https://one-sm.atlassian.net/browse/KAN-81)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/5d048fea-0ac8-4b29-b101-1471f7b55705)
